### PR TITLE
Display comment form in sidebar on single posts

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -9,5 +9,8 @@
   <div class="widget-area" >
     <?php do_action('before_sidebar'); ?>
     <?php if (!dynamic_sidebar('primary-aside')) : ?><?php endif; // end sidebar widget area ?>
+    <?php if (is_single() && comments_open()) {
+        require get_template_directory() . '/comment-form.php';
+    } ?>
   </div>
 </div><!-- #secondary -->


### PR DESCRIPTION
## Summary
- load comment form in sidebar when viewing a single post with open comments

## Testing
- `php -l sidebar.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7fedaf11c832b9936fb17354d2fb7